### PR TITLE
Revert "Bump redis from 4.5.2 to 4.5.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ django-rq==2.7.0
 django-widget-tweaks==1.4.12
 mega.py==1.0.8
 paho-mqtt==1.6.1
-redis==4.5.3
+redis==4.5.2


### PR DESCRIPTION
Reverts TaixMiguel/TaixBackups#52

redis-py through 4.5.3 leaves a connection open after canceling an async Redis command at an inopportune time (in the case of a non-pipeline operation), and can send response data to the client of an unrelated request. NOTE: this issue exists because of an incomplete fix for CVE-2023-28858.